### PR TITLE
set and restore the errors callback around each xmlsec call

### DIFF
--- a/ext/nokogiri_ext_xmlsec/init.c
+++ b/ext/nokogiri_ext_xmlsec/init.c
@@ -66,10 +66,6 @@ void Init_nokogiri_ext_xmlsec() {
     rb_raise(rb_eRuntimeError, "xmlsec-crypto initialization failed");
   }
 
-  // Set Error callback catcher last because various modules also call this.
-  // This way we always win.
-  xmlSecErrorsSetCallback(storeErrorCallback);
-
   /* ruby classes & objects */
   Init_Nokogiri_ext();
 }

--- a/ext/nokogiri_ext_xmlsec/nokogiri_decrypt_with_key.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_decrypt_with_key.c
@@ -69,6 +69,8 @@ done:
     xmlSecKeysMngrDestroy(keyManager);
   }
 
+  xmlSecErrorsSetCallback(xmlSecErrorsDefaultCallback);
+
   if(rb_exception_result != Qnil) {
     if (hasXmlSecLastError()) {
       rb_raise(rb_exception_result, "%s, XmlSec error: %s", exception_message,

--- a/ext/nokogiri_ext_xmlsec/nokogiri_encrypt_with_key.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_encrypt_with_key.c
@@ -156,6 +156,8 @@ done:
     xmlSecKeysMngrDestroy(keyManager);
   }
 
+  xmlSecErrorsSetCallback(xmlSecErrorsDefaultCallback);
+
   if(rb_exception_result != Qnil) {
     if (hasXmlSecLastError()) {
       rb_raise(rb_exception_result, "%s, XmlSec error: %s", exception_message,

--- a/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
@@ -56,6 +56,8 @@ done:
     xmlFree(name);
   }
 
+  xmlSecErrorsSetCallback(xmlSecErrorsDefaultCallback);
+
   if(rb_exception_result != Qnil) {
     if (exception_attribute_arg) {
       if (hasXmlSecLastError()) {

--- a/ext/nokogiri_ext_xmlsec/nokogiri_sign.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_sign.c
@@ -232,6 +232,8 @@ done:
     xmlSecDSigCtxDestroy(dsigCtx);
   }
 
+  xmlSecErrorsSetCallback(xmlSecErrorsDefaultCallback);
+
   if(rb_exception_result != Qnil) {
     // remove the signature node before raising an exception, so that
     // the document is untouched

--- a/ext/nokogiri_ext_xmlsec/nokogiri_verify_with.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_verify_with.c
@@ -246,6 +246,8 @@ done:
     xmlSecKeysMngrDestroy(keyManager);
   }
 
+  xmlSecErrorsSetCallback(xmlSecErrorsDefaultCallback);
+
   if(!NIL_P(rb_exception_result)) {
     if (hasXmlSecLastError()) {
       rb_raise(rb_exception_result, "%s, XmlSec error: %s", exception_message,

--- a/ext/nokogiri_ext_xmlsec/util.c
+++ b/ext/nokogiri_ext_xmlsec/util.c
@@ -102,6 +102,7 @@ int hasXmlSecLastError() {
 void resetXmlSecError() {
   g_errorStack[0] = '\0';
   g_errorStackPos = 0;
+  xmlSecErrorsSetCallback(storeErrorCallback);
 }
 
 void storeErrorCallback(const char *file,

--- a/ext/nokogiri_ext_xmlsec/xmlsecrb.h
+++ b/ext/nokogiri_ext_xmlsec/xmlsecrb.h
@@ -18,6 +18,7 @@
 #include <xmlsec/xmlenc.h>
 #include <xmlsec/templates.h>
 #include <xmlsec/crypto.h>
+#include <xmlsec/errors.h>
 
 // TODO(awong): Support non-gcc and non-clang compilers.
 #define EXTENSION_EXPORT __attribute__((visibility("default")))


### PR DESCRIPTION
to prevent conflicts with other xmlsec libraries running in the same process