### PR TITLE
Update README.md due to Centos 7 Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ to `Nokogiri::XML::Document`.
 
 ## Installation
 
+Install this before attempting to install; or else it may fail (tested on CentOS 7) while trying to find -lltdl from the xmlsec1-openssl lib. I'm guessing it's a dependency. Someone else may know more.
+    
+    yum install libtool-ltdl-devel
+
 Add this line to your application's Gemfile:
 
     gem 'nokogiri-xmlsec'


### PR DESCRIPTION
Found while trying to install nokogiri to CentOS 7. The MAKEFILE production will fail due to the missing -lltdl from xmlsec1-openssl which is from the libtool-ltdl-devel package. Someone else may be able to explain further.