### PR TITLE
Document Ubuntu (~20.04) installation tip

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ to `Nokogiri::XML::Document`.
 
 Install this before attempting to install; or else it may fail (tested on CentOS 7) while trying to find -lltdl from the xmlsec1-openssl lib. I'm guessing it's a dependency. Someone else may know more.
     
+    # CentOS/RHEL
     yum install libtool-ltdl-devel
+    
+    # Debian/Ubuntu
+    apt install -y libxmlsec1-dev
 
 Add this line to your application's Gemfile:
 


### PR DESCRIPTION
Attempting to install this gem fails on Ubuntu 20.04 until the `libxmlsec1-dev` package is installed.