### PR TITLE
Fixes #9 : Version incompatibility with nokogiri >= 1.11.2

### DIFF
--- a/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
@@ -2,7 +2,7 @@
 #include "util.h"
 
 // declaration from Nokogiri proper
-VALUE Nokogiri_wrap_xml_node(VALUE klass, xmlNodePtr node) ;
+VALUE noko_xml_node_wrap(VALUE klass, xmlNodePtr node) ;
 
 VALUE set_id_attribute(VALUE self, VALUE rb_attr_name) {
   VALUE rb_exception_result = Qnil;
@@ -14,7 +14,7 @@ VALUE set_id_attribute(VALUE self, VALUE rb_attr_name) {
   xmlChar *name = NULL;
   char *idName = NULL;
   char *exception_attribute_arg = NULL;
-  
+
   resetXmlSecError();
 
   Data_Get_Struct(self, xmlNode, node);
@@ -28,7 +28,7 @@ VALUE set_id_attribute(VALUE self, VALUE rb_attr_name) {
     exception_message = "Can't find attribute to add register as id";
     goto done;
   }
-  
+
   // get the attribute (id) value
   name = xmlNodeListGetString(node->doc, attr->children, 1);
   if(name == NULL) {
@@ -37,7 +37,7 @@ VALUE set_id_attribute(VALUE self, VALUE rb_attr_name) {
     exception_attribute_arg = idName;
     goto done;
   }
-  
+
   // check that we don't have that id already registered
   tmp = xmlGetID(node->doc, name);
   if(tmp != NULL) {
@@ -46,7 +46,7 @@ VALUE set_id_attribute(VALUE self, VALUE rb_attr_name) {
     exception_attribute_arg = idName;
     goto done;
   }
-  
+
   // finally register id
   xmlAddID(NULL, node->doc, name, attr);
 
@@ -89,7 +89,7 @@ VALUE get_id(VALUE self, VALUE rb_id)
   Data_Get_Struct(self, xmlDoc, doc);
   prop = xmlGetID(doc, (const xmlChar *)StringValueCStr(rb_id));
   if (prop) {
-    return Nokogiri_wrap_xml_node(Qnil, (xmlNodePtr)prop);
+    return noko_xml_node_wrap(Qnil, (xmlNodePtr)prop);
   } else {
     return Qnil;
   }

--- a/nokogiri-xmlsec-instructure.gemspec
+++ b/nokogiri-xmlsec-instructure.gemspec
@@ -28,8 +28,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.extensions = %w{ext/nokogiri_ext_xmlsec/extconf.rb}
 
-  spec.add_dependency 'nokogiri'
-  
+  spec.add_dependency 'nokogiri', '>= 1.11.2'
+
   spec.add_development_dependency "bundler", "~> 2.1"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
- Update nokogiri internal references from `Nokogiri_wrap_xml_node` to `noko_xml_node_wrap`
- Update nokogiri required version to >= 1.11.2
 
See sparklemotion/nokogiri@1b8d9cb