### PR TITLE
fix: support Nokogiri >= 1.13.7

### DIFF
--- a/ext/nokogiri_ext_xmlsec/common.h
+++ b/ext/nokogiri_ext_xmlsec/common.h
@@ -10,4 +10,6 @@
 
 typedef int BOOL;
 
+#define Noko_Node_Get_Struct(obj,type,sval) ((sval) = (type*)DATA_PTR(obj))
+
 #endif // NOKOGIRI_EXT_XMLSEC_COMMON_H

--- a/ext/nokogiri_ext_xmlsec/nokogiri_decrypt_with_key.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_decrypt_with_key.c
@@ -21,7 +21,7 @@ VALUE decrypt_with_key(VALUE self, VALUE rb_key_name, VALUE rb_key) {
 
   Check_Type(rb_key,      T_STRING);
   Check_Type(rb_key_name, T_STRING);
-  Data_Get_Struct(self, xmlNode, node);
+  Noko_Node_Get_Struct(self, xmlNode, node);
   key       = RSTRING_PTR(rb_key);
   keyLength = RSTRING_LEN(rb_key);
   keyName = StringValueCStr(rb_key_name);

--- a/ext/nokogiri_ext_xmlsec/nokogiri_encrypt_with_key.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_encrypt_with_key.c
@@ -53,7 +53,7 @@ VALUE encrypt_with_key(VALUE self, VALUE rb_rsa_key_name, VALUE rb_rsa_key,
     goto done;
   }
 
-  Data_Get_Struct(self, xmlNode, node);
+  Noko_Node_Get_Struct(self, xmlNode, node);
   doc = node->doc;
 
   // create encryption template to encrypt XML file and replace 

--- a/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_helpers_set_attribute_id.c
@@ -17,7 +17,7 @@ VALUE set_id_attribute(VALUE self, VALUE rb_attr_name) {
 
   resetXmlSecError();
 
-  Data_Get_Struct(self, xmlNode, node);
+  Noko_Node_Get_Struct(self, xmlNode, node);
   Check_Type(rb_attr_name, T_STRING);
   idName = StringValueCStr(rb_attr_name);
 
@@ -86,7 +86,7 @@ VALUE get_id(VALUE self, VALUE rb_id)
   xmlDocPtr doc;
 
   Check_Type(rb_id, T_STRING);
-  Data_Get_Struct(self, xmlDoc, doc);
+  Noko_Node_Get_Struct(self, xmlDoc, doc);
   prop = xmlGetID(doc, (const xmlChar *)StringValueCStr(rb_id));
   if (prop) {
     return noko_xml_node_wrap(Qnil, (xmlNodePtr)prop);

--- a/ext/nokogiri_ext_xmlsec/nokogiri_sign.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_sign.c
@@ -90,7 +90,7 @@ VALUE sign(VALUE self, VALUE rb_opts) {
     goto done;
   }
 
-  Data_Get_Struct(self, xmlNode, envelopeNode);
+  Noko_Node_Get_Struct(self, xmlNode, envelopeNode);
   doc = envelopeNode->doc;
   // create signature template for enveloped signature.
   signNode = xmlSecTmplSignatureCreate(doc, xmlSecTransformExclC14NId,

--- a/ext/nokogiri_ext_xmlsec/nokogiri_verify_with.c
+++ b/ext/nokogiri_ext_xmlsec/nokogiri_verify_with.c
@@ -146,7 +146,7 @@ VALUE verify_with(VALUE self, VALUE rb_opts) {
   resetXmlSecError();
 
   Check_Type(rb_opts, T_HASH);
-  Data_Get_Struct(self, xmlNode, node);
+  Noko_Node_Get_Struct(self, xmlNode, node);
 
   // verify start node
   if(!xmlSecCheckNodeName(node, xmlSecNodeSignature, xmlSecDSigNs)) {


### PR DESCRIPTION
Fixes #12 

Nokogiri 1.13.7 changed the typed-data semantics around xmlNode in order to
fully support compaction

see https://github.com/sparklemotion/nokogiri/pull/2579

I've tested this with older versions of Nokogiri, it's backwards-compatible.

However, reproducing `Noko_Node_Get_Struct` in this project is hacky. Perhaps in a future PR I can help find and compile against `nokogiri.h` which is findable via `Nokogiri::VERSION_INFO` metadata (cppflags). Let me know if that would be welcome.