### PR TITLE
GC compaction breaks xmlsec/nokogiri

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,3 +8,9 @@ end
 def fixture(path)
   File.read fixture_path(path)
 end
+
+RSpec.configure do |config|
+  config.after(:each) do
+    GC.compact
+  end
+end


### PR DESCRIPTION
A few releases of Nokogiri on the v1.13.x branch were to fix Nokogiri when GC compaction happens in Ruby 3.0+.

Something's still broken, and I think it's because xmlsec is freeing memory that Nokogiri still has a handle on, leading to dangling pointers that cause a problem when objects are relocated during compaction.

This PR just compacts after each spec to reproduce the issue. I'm not sure how to solve it yet, I need to do a bit more work to fully understand it.