### PR TITLE
remove dependency on XMLSEC_CRYPTO

### DIFF
--- a/ext/nokogiri_ext_xmlsec/extconf.rb
+++ b/ext/nokogiri_ext_xmlsec/extconf.rb
@@ -11,21 +11,9 @@ pkg_config('xmlsec1')
 $CFLAGS << " " + `xmlsec1-config  --cflags`.strip
 $CFLAGS << " -fvisibility=hidden"
 
-if $CFLAGS =~ /\-DXMLSEC_CRYPTO=\\\\\\"openssl\\\\\\"/
-puts "Changing escaping: #{$CFLAGS}"
-  $CFLAGS['-DXMLSEC_CRYPTO=\\\\\\"openssl\\\\\\"'] =
-    '-DXMLSEC_CRYPTO=\\"openssl\\"'
-end
-
-if $CFLAGS =~ /\-DXMLSEC_CRYPTO="openssl"/
-puts "Ensure we escaping: #{$CFLAGS}"
-  $CFLAGS['-DXMLSEC_CRYPTO="openssl"'] =
-  '-DXMLSEC_CRYPTO=\\"openssl\\"'
-end
-
 $CFLAGS << Dir[Gem.loaded_specs['nokogiri'].full_gem_path + "/ext/*"].map { |dir| " -I#{dir}"}.join("")
 
-puts "Clfags: #{$CFLAGS}"
+puts "Cflags: #{$CFLAGS}"
 $libs = `xmlsec1-config  --libs`.strip
 
 # We reference symbols out of nokogiri but don't link directly against it

--- a/ext/nokogiri_ext_xmlsec/init.c
+++ b/ext/nokogiri_ext_xmlsec/init.c
@@ -47,7 +47,7 @@ void Init_nokogiri_ext_xmlsec() {
   }
   // load crypto
   #ifdef XMLSEC_CRYPTO_DYNAMIC_LOADING
-    if(xmlSecCryptoDLLoadLibrary(BAD_CAST XMLSEC_CRYPTO) < 0) {
+    if(xmlSecCryptoDLLoadLibrary(NULL) < 0) {
       rb_raise(rb_eRuntimeError,
         "Error: unable to load default xmlsec-crypto library. Make sure"
         "that you have it installed and check shared libraries path\n"

--- a/lib/xmlsec/version.rb
+++ b/lib/xmlsec/version.rb
@@ -1,3 +1,3 @@
 module Xmlsec
-  VERSION = '0.10.2'
+  VERSION = '0.10.3'
 end

--- a/spec/fixtures/sign3-result.xml
+++ b/spec/fixtures/sign3-result.xml
@@ -32,7 +32,8 @@ eymfHtzOeY86WyvfsjZmaz2XnIo9dzZsK71yMEKkgvXQnnYy9pK0NaYcG0B0hcii
 gSVEWpEpCSo560x0mSuLnJYdQQzZ/L6xvxZ1AgMBAAEwDQYJKoZIhvcNAQEFBQAD
 gYEATyK/RlfpohUVimgFkycTF2hyusjctseXoZDCctgg/STMsL8iA0P9YB6k91GC
 kWpwevuiwarD1MfSUV6goPINFkIBvfK+5R9lpHaTqqs615z8T9R5VJgaLcFe3tWd
-7oq3V2q5Nl6MrZfXj2N07qe6/9zfdauxYO26vAEKCvIkbMo=</X509Certificate>
+7oq3V2q5Nl6MrZfXj2N07qe6/9zfdauxYO26vAEKCvIkbMo=
+</X509Certificate>
 </X509Data>
 </KeyInfo>
 </Signature></Envelope>


### PR DESCRIPTION
It was deprecated in 1.2.21 (2016-04-12), and completely removed in 1.3.0 (2023-04-12).