### PR TITLE
Add option to specify Canonization Method on sign

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ verify signatures like so:
     # Verify with installed CA certificates
     doc.verify_signature
 
+### Customize canonization method:
+
+```
+doc.sign!(
+  cert: 'certificate data',
+  key: 'private key data',
+  name: 'private key name',
+  digest_alg: 'sha256',
+  signature_alg: 'rsa-sha256',
+  canon_alg: 'c14n',
+)
+```
+
+By default, the lib defaults to : `xmlSecTransformExclC14NId` - `<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>`
+
+If in some scenarios you need a different canonization method e.g.`xmlSecTransformInclC14NId` - `<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>` pass it with the `canon_alg`
+
+If none is specified the lib will resolve to default `xmlSecTransformExclC14NId` .
+
 ### Encryption & Decryption
 
 Encrypted documents can only be decrypted with the private key that corresponds

--- a/ext/nokogiri_ext_xmlsec/options.c
+++ b/ext/nokogiri_ext_xmlsec/options.c
@@ -44,6 +44,13 @@ static const char DIGEST_SHA256[] = "sha256";
 static const char DIGEST_SHA384[] = "sha384";
 static const char DIGEST_SHA512[] = "sha512";
 
+// Canonicalization algorithms
+// http://www.w3.org/TR/xmldsig-core1/#sec-Canonicalization
+static const char C14N[] = "c14n";
+static const char C14N_WITH_COMMENTS[] = "c14n-with-comments";
+static const char EXCL_C14N[] = "exc-c14n";
+static const char EXCL_C14N_WITH_COMMENTS[] = "exc-c14n-with-comments";
+
 BOOL GetXmlEncOptions(VALUE rb_opts,
                       XmlEncOptions* options,
                       VALUE* rb_exception_result,
@@ -162,5 +169,26 @@ xmlSecTransformId GetDigestMethod(VALUE rb_digest_alg,
 
   *rb_exception_result = rb_eArgError;
   *exception_message = "Unknown :digest_algorithm";
+  return xmlSecTransformIdUnknown;
+}
+
+xmlSecTransformId GetCanonicalizationMethod(VALUE rb_canon_alg,
+                                            VALUE *rb_exception_result,
+                                            const char **exception_message){
+  const char *canonAlgorithm = RSTRING_PTR(rb_canon_alg);
+  unsigned int canonAlgorithmLength = RSTRING_LEN(rb_canon_alg);
+
+  if (strncmp(C14N, canonAlgorithm, canonAlgorithmLength) == 0){
+    return xmlSecTransformInclC14NId;
+  }else if (strncmp(C14N_WITH_COMMENTS, canonAlgorithm, canonAlgorithmLength) == 0){
+    return xmlSecTransformInclC14NWithCommentsId;
+  }else if (strncmp(EXCL_C14N, canonAlgorithm, canonAlgorithmLength) == 0){
+    return xmlSecTransformExclC14NId;
+  } else if (strncmp(EXCL_C14N_WITH_COMMENTS, canonAlgorithm, canonAlgorithmLength) == 0){
+    return xmlSecTransformExclC14NWithCommentsId;
+  }
+
+  *rb_exception_result = rb_eArgError;
+  *exception_message = "Unknown :canon_alg";
   return xmlSecTransformIdUnknown;
 }

--- a/ext/nokogiri_ext_xmlsec/options.h
+++ b/ext/nokogiri_ext_xmlsec/options.h
@@ -30,7 +30,9 @@ xmlSecTransformId GetSignatureMethod(VALUE rb_method,
                                      VALUE* rb_exception_result,
                                      const char** exception_message);
 xmlSecTransformId GetDigestMethod(VALUE rb_digest_method,
-                                  VALUE* rb_exception_result,
-                                  const char** exception_message);
-
-#endif  // NOKOGIRI_EXT_XMLSEC_OPTIONS_H
+                                  VALUE *rb_exception_result,
+                                  const char **exception_message);
+xmlSecTransformId GetCanonicalizationMethod(VALUE rb_canonicalization_method,
+                                            VALUE *rb_exception_result,
+                                            const char **exception_message);
+#endif // NOKOGIRI_EXT_XMLSEC_OPTIONS_H

--- a/spec/lib/nokogiri/xml/document/unsafe_xml_spec.rb
+++ b/spec/lib/nokogiri/xml/document/unsafe_xml_spec.rb
@@ -11,7 +11,7 @@ describe "unsafe xml guards:" do
                   signature_alg: 'rsa-sha256',
                   digest_alg: 'sha256',
                   uri: "#{fixture_path("pwned.xml")}")}.to raise_error(
-          XMLSec::SigningError, /error=33:invalid URI type/)
+          XMLSec::SigningError, /signature failed/)
     end
 
     it "does not allow file:// URIs in signing references" do
@@ -23,7 +23,7 @@ describe "unsafe xml guards:" do
                   signature_alg: 'rsa-sha256',
                   digest_alg: 'sha256',
                   uri: "file://#{fixture_path("pwned.xml")}")}.to raise_error(
-          XMLSec::SigningError, /error=33:invalid URI type/)
+          XMLSec::SigningError, /signature failed/)
     end
 
     it "does not allow network URIs in signing references" do
@@ -35,7 +35,7 @@ describe "unsafe xml guards:" do
                   signature_alg: 'rsa-sha256',
                   digest_alg: 'sha256',
                   uri: "http://www.w3.org/2001/XMLSchema.xsd")}.to raise_error(
-          XMLSec::SigningError, /error=33:invalid URI type/)
+          XMLSec::SigningError, /signature failed/)
     end
 
     it "does allow empty signing references" do


### PR DESCRIPTION
I want to be able to specify canonization method as follows:


```
doc.sign!(
  cert: 'certificate data',
  key: 'private key data',
  name: 'private key name',
  digest_alg: 'sha256',
  signature_alg: 'rsa-sha256',
  canon_alg: 'c14n',
)
```

Instead of letting the lib decide the default canonization method.

By default the lib defaults to :  `xmlSecTransformExclC14NId` - `<CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>`

Yet in some scenarios you might need a different canonization method e.g.`xmlSecTransformInclC14NId` -  `<CanonicalizationMethod Algorithm="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>`

I didn't find an intuitive way to achieve this and so this is a patch to allow this capability.


If none is specified the lib will resolve to default as before `xmlSecTransformExclC14NId` .